### PR TITLE
Avoid encrypting the data EBS volume

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,6 @@ Features:
 * fully-automated setup including Elastic IPs, EC2 security groups, SSL certs
 * multi-region replication (Ec2MultiRegionSnitch_)
 * encrypted inter-node communication (SSL/TLS)
-* encrypted EBS storage volumes
 * `EC2 Auto Recovery`_ enabled
 * Jolokia_ agent to expose JMX metrics via HTTP
 

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -389,7 +389,7 @@ def launch_instance(region: str, ip: dict, ami: object, subnet_id: str,
         data_ebs = {'VolumeType': options['volume_type'],
                     'VolumeSize': options['volume_size'],
                     'DeleteOnTermination': False,
-                    'Encrypted': True}
+                    'Encrypted': False}
         if options['volume_type'] == 'io1':
             data_ebs['Iops'] = options['volume_iops']
 

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -385,7 +385,10 @@ def launch_instance(region: str, ip: dict, ami: object, subnet_id: str,
                 block_devices.append({'DeviceName': bd['DeviceName'],
                                       'NoDevice': ''})
 
-        # make sure our data EBS volume is persisted and encrypted
+        #
+        # Make sure our data EBS volume is persisted, but NOT
+        # encrypted: the latter will prevent auto-recovery.
+        #
         data_ebs = {'VolumeType': options['volume_type'],
                     'VolumeSize': options['volume_size'],
                     'DeleteOnTermination': False,


### PR DESCRIPTION
This is a major oversight and may effectively prevent successful
auto-recovery of the affected instance when it's actually triggered.