### PR TITLE
Fix data and commit log dir placement

### DIFF
--- a/planb-cassandra.sh
+++ b/planb-cassandra.sh
@@ -46,8 +46,8 @@ else
 fi
 echo "Broadcast IP address is $BROADCAST_ADDRESS ..."
 
-export DATA_DIR=${DATA_DIR:-/var/lib/cassandra}
-export COMMIT_LOG_DIR=${COMMIT_LOG_DIR:-/var/lib/cassandra/commit_logs}
+export DATA_DIR=${DATA_DIR:-/var/lib/cassandra/data}
+export COMMIT_LOG_DIR=${COMMIT_LOG_DIR:-/var/lib/cassandra/commitlog}
 
 if [ -z "$TRUSTSTORE" ]; then
     echo "TRUSTSTORE must be set (base64 encoded)."


### PR DESCRIPTION
A possible gotcha is when you want to update an already running system
to the new docker image that contains this change.  Moving dirs around
manually will be required before starting the new image.

Closes #60