### PR TITLE
Fix cqlsh history problem (bash hopefully as well)

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -45,7 +45,7 @@ RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
 COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
-WORKDIR /var/lib/cassandra
+WORKDIR $HOME
 
 CMD planb-cassandra.sh
 

--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -44,6 +44,9 @@ RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
 
 COPY planb-cassandra.sh /usr/local/bin/
 
+ENV HOME=/var/lib/cassandra
+WORKDIR /var/lib/cassandra
+
 CMD planb-cassandra.sh
 
 COPY scm-source.json /

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -48,6 +48,9 @@ RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
 
 COPY planb-cassandra.sh /usr/local/bin/
 
-COPY scm-source.json /
+ENV HOME=/var/lib/cassandra
+WORKDIR /var/lib/cassandra
 
 CMD planb-cassandra.sh
+
+COPY scm-source.json /

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -49,7 +49,7 @@ RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
 COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
-WORKDIR /var/lib/cassandra
+WORKDIR $HOME
 
 CMD planb-cassandra.sh
 


### PR DESCRIPTION
Given how cqlsh tries to find the history, the only way is to set HOME
to something where the default docker user has permissions to write.

This ends up on the data volume, but should not be an issue since if you
got one, you get a lot of the actual data already.