### PR TITLE
Update to the currently latest base Docker images

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-39
+FROM registry.opensource.zalan.do/stups/openjdk:8-42
 
 MAINTAINER Zalando SE
 

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-39
+FROM registry.opensource.zalan.do/stups/openjdk:8-42
 
 MAINTAINER Zalando SE
 

--- a/Dockerfiles/Scylla-1.3/Dockerfile
+++ b/Dockerfiles/Scylla-1.3/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:16.04
+FROM registry.opensource.zalan.do/stups/ubuntu:16.04-48
+
 RUN apt-get update
 RUN apt-get install -y wget vim
 RUN wget -O /etc/apt/sources.list.d/scylla.list http://downloads.scylladb.com/deb/ubuntu/scylla-1.3-xenial.list


### PR DESCRIPTION
This fixes recent OpenSSL CVEs.  Also switch ScyllaDB base image from
Docker hub to Zalando OS registry.