### PR TITLE
Fix user.home property for running under Taupage

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -46,6 +46,7 @@ COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
 WORKDIR $HOME
+RUN echo "JVM_OPTS=-Duser.home=$HOME" >>/usr/share/cassandra/cassandra.in.sh
 
 CMD planb-cassandra.sh
 

--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -46,7 +46,7 @@ COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
 WORKDIR $HOME
-RUN echo "JVM_OPTS=-Duser.home=$HOME" >>/usr/share/cassandra/cassandra.in.sh
+RUN echo 'JVM_OPTS="$JVM_OPTS -Duser.home=$HOME"' >>/usr/share/cassandra/cassandra.in.sh
 
 CMD planb-cassandra.sh
 

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -50,7 +50,7 @@ COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
 WORKDIR $HOME
-RUN echo "JVM_OPTS=-Duser.home=$HOME" >>/usr/share/cassandra/cassandra.in.sh
+RUN echo 'JVM_OPTS="$JVM_OPTS -Duser.home=$HOME"' >>/usr/share/cassandra/cassandra.in.sh
 
 CMD planb-cassandra.sh
 

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -50,6 +50,7 @@ COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra
 WORKDIR $HOME
+RUN echo "JVM_OPTS=-Duser.home=$HOME" >>/usr/share/cassandra/cassandra.in.sh
 
 CMD planb-cassandra.sh
 


### PR DESCRIPTION
Ever Since we've fixed the HOME/current directory, nodetool tries to
save its history in a file named $HOME/.cassandra/nodetool.history

But because of the way Taupage runs docker, value of "user.home" system
property under Java is returned as "?".  Which makes it create literally
a directory named "?" in /var/lib/cassandra, which is very confusing.

It is not apparent why nodetool tries to save its history in a file in
the first place and there doesn't seem to be a flag to turn it off.