### PR TITLE
Fix default volume size (for testing only)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Available options are::
     --num-tokens	Number of virtual nodes per node.  Default: 256
     --instance-type	AWS EC2 instance type to use for the nodes.  Default: t2.medium
     --volume-type	Type of EBS data volume to create for every node.  Default: gp2 (General Purpose SSD).
-    --volume-size	Size of EBS data volume in GB for every node.  Default: 8
+    --volume-size	Size of EBS data volume in GB for every node.  Default: 16
     --volume-iops	Number of provisioned IOPS for the volumes, used only for volume type of io1.  Default: 100 (when applicable).
     --no-termination-protection	Don't protect EC2 instances from accidental termination.  Useful for testing and development.
     --internal		Deploy the cluster within one region, using private IPs only.

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -554,7 +554,7 @@ either correct the error or retry.
 @click.option('--num-tokens', default=256, type=int, help='number of virtual nodes per node, default: 256')
 @click.option('--instance-type', default='t2.medium', help='default: t2.medium')
 @click.option('--volume-type', default='gp2', help='gp2 (default) | io1 | standard')
-@click.option('--volume-size', default=8, type=int, help='in GB, default: 8')
+@click.option('--volume-size', default=16, type=int, help='in GB, default: 16')
 @click.option('--volume-iops', default=100, type=int, help='for type io1, default: 100')
 @click.option('--no-termination-protection', is_flag=True, default=False)
 @click.option('--internal', is_flag=True, default=False, help='deploy into internal subnets using Private IP addresses, to be used with a single region only')


### PR DESCRIPTION
Old default of 8 GB is not really suitable for testing.  The commitlog
alone can grow up to 8 GB and kill the instance.  Set to 16.