### PR TITLE
Fix cassandra server command line for 3.0.x

### DIFF
--- a/Dockerfiles/Cassandra-3.0.x/planb-cassandra.sh
+++ b/Dockerfiles/Cassandra-3.0.x/planb-cassandra.sh
@@ -86,7 +86,7 @@ echo "Generating configuration from template ..."
 python -c "import sys, os; sys.stdout.write(os.path.expandvars(open('/etc/cassandra/cassandra_template.yaml').read()))" > /etc/cassandra/cassandra.yaml
 
 echo "Starting Cassandra ..."
-/usr/sbin/cassandra -R -f &
+/usr/sbin/cassandra -f &
 
 #
 # Try to override default superuser password (we don't care if it


### PR DESCRIPTION
The -R flag is needed for tick-tock, but 3.0 knows nothing about it.