### PR TITLE
Allow to suppress setting appdynamics_application

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,12 @@ If you use the Hosted Zone parameter, a full name specification is
 required e.g.: ``--hosted-zone myzone.example.com.`` (note the
 trailing dot.)
 
+By default AppDynamics agent will be started with application name set
+to the cluster name.  You can suppress this if you don't want the
+overhead of the agent (or using a different log shipping mechanism,
+such as Scalyr.)  To do so pass an empty string for this parameter
+``--appdynamics-application=''``.
+
 It might be required to update the Security Group(s) to allow SSH
 access (TCP port 22) from Odd_ host.  After that is done, you can use
 `Più`_ to get SSH access and create your application user and the

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -354,9 +354,17 @@ def generate_taupage_user_data(options: dict) -> str:
                     'options': 'noatime,nodiratime'
                 }
             },
-            'appdynamics_application': options['appdynamics_application'] or options['cluster_name'],
             'scalyr_account_key': options['scalyr_key']
     }
+
+    app_name = options['appdynamics_application']
+    if app_name is None:
+        data['appdynamics_application'] = options['cluster_name']
+    elif app_name:
+        data['appdynamics_application'] = app_name
+    else:
+        # it must be an empty string then: don't set anything in user data
+        pass
 
     if options['environment']:
         data['environment'].update(options['environment'])


### PR DESCRIPTION
On small instances or where Scalyr is still used, this doesn't make
sense.  Passing an empty string for this parameter allows to suppres
starting the agent in Taupage.