### PR TITLE
Possibility to pass instance profile name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,7 +268,7 @@ data that the node is no longer responsible for.
 .. _Jolokia: https://jolokia.org/
 .. _STUPS Cassandra: https://github.com/zalando/stups-cassandra
 .. _Più: http://docs.stups.io/en/latest/components/piu.html
-.. _Using Instance Profiles http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+.. _Using Instance Profiles: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 
 Upgrade your cluster from Cassandra 2.1 -> 3.0.x
 ===================

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ Available options are::
     --environment, -e	Extend/override environment section of Taupage user data.
     --sns-topic		Amazon SNS topic name to use for notifications about Auto-Recovery.
     --sns-email		Email address to subscribe to Amazon SNS notification topic.  See below for details.
+    --instance-profile-name Instance profile name to be used when launching instance (optional). See below for details.
 
 In order to be able to receive notification emails in case instance
 recovery is triggered, provide either SNS topic name in
@@ -92,6 +93,12 @@ It might be required to update the Security Group(s) to allow SSH
 access (TCP port 22) from Odd_ host.  After that is done, you can use
 `Più`_ to get SSH access and create your application user and the
 first schema:
+
+If you want to associate instance profile to your instances specify
+the name of the instance profile with ``--instance-profile-name``.
+The instance profile must exist. When you create IAM role with console, instance
+profile is created automatically with same name. When creating roles with aws cli,
+you need to create both separately. See more `Using Instance Profiles`_
 
 .. code-block:: bash
 
@@ -261,6 +268,7 @@ data that the node is no longer responsible for.
 .. _Jolokia: https://jolokia.org/
 .. _STUPS Cassandra: https://github.com/zalando/stups-cassandra
 .. _Più: http://docs.stups.io/en/latest/components/piu.html
+.. _Using Instance Profiles http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
 
 Upgrade your cluster from Cassandra 2.1 -> 3.0.x
 ===================

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -572,7 +572,7 @@ either correct the error or retry.
 @click.option('--environment', '-e', multiple=True)
 @click.option('--sns-topic', help='SNS topic name to send Auto-Recovery notifications to')
 @click.option('--sns-email', help='Email address to subscribe to Auto-Recovery SNS topic')
-@click.option('--instance-profile-name', help='Instance profile name to be used, optional')
+@click.option('--instance-profile-name', help='Instance profile name to be used')
 @click.argument('regions', nargs=-1)
 def cli(regions: list,
         cluster_name: str, cluster_size: int, num_tokens: int,

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -416,6 +416,11 @@ def launch_instance(region: str, ip: dict, ami: object, subnet_id: str,
         #
         block_devices.append({'DeviceName': '/dev/xvdf', 'Ebs': data_ebs})
 
+        if options['instance_profile_name']:
+           instance_profile_name={'Name': options['instance_profile_name']}
+        else:
+           instance_profile_name={}
+
         resp = ec2.run_instances(
             ImageId=ami.id,
             MinCount=1,
@@ -426,6 +431,7 @@ def launch_instance(region: str, ip: dict, ami: object, subnet_id: str,
             SubnetId=subnet_id,
             PrivateIpAddress=ip['PrivateIp'],
             BlockDeviceMappings=block_devices,
+            IamInstanceProfile=instance_profile_name,
             DisableApiTermination=not(options['no_termination_protection']))
 
         instance = resp['Instances'][0]
@@ -566,6 +572,7 @@ either correct the error or retry.
 @click.option('--environment', '-e', multiple=True)
 @click.option('--sns-topic', help='SNS topic name to send Auto-Recovery notifications to')
 @click.option('--sns-email', help='Email address to subscribe to Auto-Recovery SNS topic')
+@click.option('--instance-profile-name', help='Instance profile name to be used, optional')
 @click.argument('regions', nargs=-1)
 def cli(regions: list,
         cluster_name: str, cluster_size: int, num_tokens: int,
@@ -573,7 +580,7 @@ def cli(regions: list,
         no_termination_protection: bool, use_dmz: bool, hosted_zone: str,
         scalyr_key: str, appdynamics_application: str,
         artifact_name: str, docker_image: str, environment: list,
-        sns_topic: str, sns_email: str):
+        sns_topic: str, sns_email: str, instance_profile_name: str):
 
     if not cluster_name:
         raise click.UsageError('You must specify the cluster name')


### PR DESCRIPTION
This option will allow passing existing instance profile name (=iam role) when launching instances. 

That would make possible to configure backups to s3 for example.

The instance profile name is optional.



 