### PR TITLE
Enable remote JMX on Cassandra 2

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.opensource.zalan.do/stups/openjdk:8-50
 MAINTAINER Zalando SE
 
 # SSL Storage Port, Jolokia Agent, CQL Native
-EXPOSE 7001 8778 9042
+EXPOSE 7001 7199 8778 9042
 
 ENV CASSIE_VERSION=2.1.16
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfiles/Cassandra-2/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-2/cassandra-env.sh
@@ -278,7 +278,7 @@ JVM_OPTS="$JVM_OPTS -Djava.net.preferIPv4Stack=true"
 # To enable remote JMX connections, uncomment lines below
 # with authentication and/or ssl enabled. See https://wiki.apache.org/cassandra/JmxSecurity 
 #
-LOCAL_JMX=yes
+LOCAL_JMX=not-only
 
 if [ "$LOCAL_JMX" = "yes" ]; then
   JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT -XX:+DisableExplicitGC"
@@ -286,8 +286,8 @@ else
   JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.port=$JMX_PORT"
   JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
   JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.ssl=false"
-  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=true"
-  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password"
+  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
+#  JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password"
 #  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStore=/path/to/keystore"
 #  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.keyStorePassword=<keystore-password>"
 #  JVM_OPTS="$JVM_OPTS -Djavax.net.ssl.trustStore=/path/to/truststore"


### PR DESCRIPTION
In order to test Cassandra reaper.