### PR TITLE
Update OpenJDK to avoid CVEs

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-50
+FROM registry.opensource.zalan.do/stups/openjdk:8-cd26
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
For Cassandra-2 only for now.