### PR TITLE
Make jmx public

### DIFF
--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.opensource.zalan.do/stups/openjdk:8-50
 
 MAINTAINER Zalando SE
 
-# SSL Storage Port, Jolokia Agent, CQL Native
+# SSL Storage Port, Jolokia Agent, JMX,  CQL Native
 EXPOSE 7001 7199 8778 9042 
 
 ENV CASSIE_VERSION=39x

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.opensource.zalan.do/stups/openjdk:8-50
 MAINTAINER Zalando SE
 
 # SSL Storage Port, Jolokia Agent, CQL Native
-EXPOSE 7001 8778 9042
+EXPOSE 7001 7199 8778 9042 
 
 ENV CASSIE_VERSION=39x
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfiles/Cassandra-3/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3/cassandra-env.sh
@@ -234,7 +234,9 @@ fi
 # JMX connections.
 # For security reasons, you should not expose this port to the internet.  Firewall it if needed.
 JMX_PORT="7199"
-JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.local.port=$JMX_PORT"
+# Make JMX Public
+JVM_OPTS="$JVM_OPTS -Dcassandra.jmx.remote.port=$JMX_PORT"
+JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT"
 JVM_OPTS="$JVM_OPTS -Dcom.sun.management.jmxremote.authenticate=false"
 
 # jmx ssl options


### PR DESCRIPTION
Since we are integrating cassandra-reaper we need to have this ports accessible from remote. Furthermore JMX is already accessible from remote on the 2.x branch.