### PR TITLE
Root out AppDynamics for newly created cluster

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,6 @@ Available options are:
 --use-dmz                    Deploy the cluster into DMZ subnets using Public IPs (required for multi-region setup).
 --hosted-zone                Specify this to create SRV records for every region, listing all nodes' private IP addresses in that region.  This is optional.
 --scalyr-key                 Write Logs API Key for Scalyr (optional).
---appdynamics-application    Name of the application for AppDynamics log shipping (optional).
 --artifact-name              Override Pierone artifact name.  Default: planb-cassandra-3.0
 --docker-image               Override default Docker image.
 --environment, -e            Extend/override environment section of Taupage user data.
@@ -124,12 +123,6 @@ specified, then it will be subscribed to the topic.
 If you use the Hosted Zone parameter, a full name specification is
 required e.g.: ``--hosted-zone myzone.example.com.`` (note the
 trailing dot.)
-
-By default AppDynamics agent will be started with application name set
-to the cluster name.  You can suppress this if you don't want the
-overhead of the agent (or using a different log shipping mechanism,
-such as Scalyr.)  To do so pass an empty string for this parameter
-``--appdynamics-application=''``.
 
 It might be required to update the Security Group(s) of the Cassandra
 cluster to allow SSH access (TCP port 22, Jolokia Port 8778) from Odd_

--- a/planb/cli.py
+++ b/planb/cli.py
@@ -34,7 +34,6 @@ def cli(debug: bool):
 @click.option('--use-dmz', is_flag=True, default=False, help='deploy into DMZ subnets using Public IP addresses')
 @click.option('--hosted-zone', help='create SRV records in this Hosted Zone')
 @click.option('--scalyr-key')
-@click.option('--appdynamics-application', help='Please specify the appdynamics application name to be used')
 @click.option('--artifact-name', help='Pierone artifact name to use (default: planb-cassandra-3.0)')
 @click.option('--docker-image', help='Docker image to use (default: latest planb-cassandra-3.0)')
 @click.option('--environment', '-e', multiple=True)
@@ -52,7 +51,6 @@ def create(regions: list,
            use_dmz: bool,
            hosted_zone: str,
            scalyr_key: str,
-           appdynamics_application: str,
            artifact_name: str,
            docker_image: str,
            environment: list,

--- a/planb/create_cluster.py
+++ b/planb/create_cluster.py
@@ -365,15 +365,6 @@ def generate_taupage_user_data(options: dict) -> str:
             'scalyr_account_key': options['scalyr_key']
     }
 
-    app_name = options['appdynamics_application']
-    if app_name is None:
-        data['appdynamics_application'] = options['cluster_name']
-    elif app_name:
-        data['appdynamics_application'] = app_name
-    else:
-        # it must be an empty string then: don't set anything in user data
-        pass
-
     if options['environment']:
         data['environment'].update(options['environment'])
 


### PR DESCRIPTION
The idea of using it for Cassandra log shipping didn't prove helpful, let's
not create at least the new clusters with that thing.