### PR TITLE
Add SNS options for update subcommand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,12 @@ the last used node.
 
     $ zaws re $ACCOUNT
     $ piu re -O $ODDHOST $ODDHOST
-    $ ./planb.py update --cluster-name mycluster --docker-image registry.opensource.zalan.do/stups/planb-cassandra-3.0:cd-69 --region eu-central-1 -O $ODDHOST
+    $ ./planb.py update --cluster-name mycluster \
+        --docker-image registry.opensource.zalan.do/stups/planb-cassandra-3.0:cd-69 \
+        --region eu-central-1 \
+        -O $ODDHOST \
+        --sns-topic planb-cassandra-system-event \
+        --sns-email test@example.com
 
 Available options for update:
 
@@ -183,6 +188,8 @@ Available options for update:
 --region               The region where the update should be applied (required)
 --docker-image         The full specified name of the Docker image
 --taupage-ami-id       The full specified name of the AMI
+--sns-topic            Amazon SNS topic name to use for notifications about Auto-Recovery.
+--sns-email            Email address to subscribe to Amazon SNS notification topic.  See description of ``create`` subcommand above for details.
 =================      ========================================================
 
 

--- a/planb/cli.py
+++ b/planb/cli.py
@@ -85,11 +85,15 @@ def create(regions: list,
 @click.option('--region', type=str, required=True)
 @click.option('--docker-image', type=str)
 @click.option('--taupage-ami-id', type=str)
+@click.option('--sns-topic', help='SNS topic name to send Auto-Recovery notifications to')
+@click.option('--sns-email', help='Email address to subscribe to Auto-Recovery SNS topic')
 def update(cluster_name: str,
            odd_host: str,
            region: str,
            docker_image: str,
-           taupage_ami_id: str):
+           taupage_ami_id: str,
+           sns_topic: str,
+           sns_email: str):
 
     if not(docker_image or taupage_ami_id):
         raise click.UsageError("Please specify at least one of --docker-image or --taupage-ami-id")

--- a/planb/create_cluster.py
+++ b/planb/create_cluster.py
@@ -21,7 +21,8 @@ import copy
 import netaddr
 
 from .common import override_ephemeral_block_devices, dump_user_data_for_taupage, \
-    create_auto_recovery_alarm, create_instance_profile
+    setup_sns_topics_for_alarm, create_auto_recovery_alarm, \
+    create_instance_profile
 
 
 def setup_security_groups(use_dmz: bool, cluster_name: str, node_ips: dict,
@@ -305,21 +306,6 @@ def setup_dns_records(cluster_name: str, hosted_zone: str, node_ips: dict):
                         }
                     }]
                 })
-
-
-def setup_sns_topics_for_alarm(regions: list, topic_name: str, email: str) -> list:
-    if not(topic_name):
-        topic_name = 'planb-cassandra-system-event'
-
-    result = {}
-    for region in regions:
-        sns = boto3.client('sns', region_name=region)
-        resp = sns.create_topic(Name=topic_name)
-        topic_arn = resp['TopicArn']
-        if email:
-            sns.subscribe(TopicArn=topic_arn, Protocol='email', Endpoint=email)
-        result[region] = topic_arn
-    return result
 
 
 def generate_taupage_user_data(options: dict) -> str:

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -18,7 +18,6 @@ from .common import ec2_client, \
     dump_user_data_for_taupage, list_instances, \
     override_ephemeral_block_devices, \
     setup_sns_topics_for_alarm, create_auto_recovery_alarm, \
-    override_ephemeral_block_devices, create_auto_recovery_alarm, \
     create_instance_profile, get_instance_profile
 
 


### PR DESCRIPTION
It works the same way as in create subcommand.  If you don't specify an SNS
topic, the new alarm created for autorecovery will not trigger notification.