### PR TITLE
Allow instance type to be upgraded

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,16 +175,17 @@ the last used node.
 
 Available options for update:
 
-=================      ========================================================
---cluster-name         The name of your cluster (required)
---odd-host             The Odd host in the region of your VPC (required)
---region               The region where the update should be applied (required)
---force-termination    Disable termination protection for the duration of update
---docker-image         The full specified name of the Docker image
---taupage-ami-id       The full specified name of the AMI
---sns-topic            Amazon SNS topic name to use for notifications about Auto-Recovery.
---sns-email            Email address to subscribe to Amazon SNS notification topic.  See description of ``create`` subcommand above for details.
-=================      ========================================================
+===================  ========================================================
+--cluster-name       The name of your cluster (required)
+--odd-host           The Odd host in the region of your VPC (required)
+--region             The region where the update should be applied (required)
+--force-termination  Disable termination protection for the duration of update
+--docker-image       The full specified name of the Docker image
+--taupage-ami-id     The full specified name of the AMI
+--instance-type      The type of instance to deploy each node on (e.g. t2.medium)
+--sns-topic          Amazon SNS topic name to use for notifications about Auto-Recovery.
+--sns-email          Email address to subscribe to Amazon SNS notification topic.  See description of ``create`` subcommand above for details.
+===================  ========================================================
 
 
 Client configuration for Public IPs setup

--- a/planb/cli.py
+++ b/planb/cli.py
@@ -89,6 +89,7 @@ sns_email_help = 'Email address to subscribe to Auto-Recovery SNS topic'
 @click.option('--force-termination', is_flag=True, default=False)
 @click.option('--docker-image', type=str)
 @click.option('--taupage-ami-id', type=str)
+@click.option('--instance-type', type=str)
 @click.option('--sns-topic', help=sns_topic_help)
 @click.option('--sns-email', help=sns_email_help)
 def update(cluster_name: str,
@@ -97,6 +98,7 @@ def update(cluster_name: str,
            force_termination: bool,
            docker_image: str,
            taupage_ami_id: str,
+           instance_type: str,
            sns_topic: str,
            sns_email: str):
 

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -274,7 +274,7 @@ def build_run_instances_params(
         IamInstanceProfile=instance_profile
     )
 
-    options_to_api = {'taupage_ami_id': 'ImageId'}
+    options_to_api = {'taupage_ami_id': 'ImageId', 'instance_type': 'InstanceType'}
     instance_changes = {
         v: options[k]
         for k, v in options_to_api.items()

--- a/tests/test_update_cluster.py
+++ b/tests/test_update_cluster.py
@@ -51,14 +51,15 @@ def test_build_run_instances_params():
     options = {
         'cluster_name': 'my-cluster-name',
         'docker_image': 'docker.registry/cassandra:123',
-        'taupage_ami_id': 'ami-654321'
+        'taupage_ami_id': 'ami-654321',
+        'instance_type': 'm4.xlarge'
     }
     expected = {
         'MinCount': 1,
         'MaxCount': 1,
         'ImageId': 'ami-654321',
         'SecurityGroupIds': ['sg-abcdef', 'sg-654321'],
-        'InstanceType': 't2.micro',
+        'InstanceType': 'm4.xlarge',
         'SubnetId': 'sn-123',
         'PrivateIpAddress': '172.31.128.11',
         'BlockDeviceMappings': [],


### PR DESCRIPTION
Add new command line option --instance-type to the update command
Fix documentation to allow the update options table to be rendered