### PR TITLE
Update to new Cassandra releases

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Zalando SE
 # SSL Storage Port, Jolokia Agent, CQL Native
 EXPOSE 7001 7199 8778 9042
 
-ENV CASSIE_VERSION=2.1.17
+ENV CASSIE_VERSION=2.1.18
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 21x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Zalando SE
 # SSL Storage Port, Jolokia Agent, CQL Native
 EXPOSE 7001 8778 9042
 
-ENV CASSIE_VERSION=3.0.13
+ENV CASSIE_VERSION=3.0.14
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 30x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -3,9 +3,9 @@ FROM registry.opensource.zalan.do/stups/openjdk:latest
 MAINTAINER Zalando SE
 
 # SSL Storage Port, Jolokia Agent, JMX,  CQL Native
-EXPOSE 7001 7199 8778 9042 
+EXPOSE 7001 7199 8778 9042
 
-ENV CASSIE_VERSION=3.10
+ENV CASSIE_VERSION=3.11
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 310x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list


### PR DESCRIPTION
Update to Cassandra 2.1.18, 3.0.14 and 3.11