### PR TITLE
Fix "permission denied" when creating cassandra-rackdc.properties

### DIFF
--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -41,7 +41,9 @@ COPY cassandra-env.sh-original /etc/cassandra/
 # Override logging: STDOUT only
 COPY logback.xml /etc/cassandra/
 
-RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
+RUN rm -f /etc/cassandra/cassandra.yaml \
+          /etc/cassandra/cassandra-rackdc.properties && \
+    chmod 0777 /etc/cassandra
 
 COPY planb-cassandra.sh /usr/local/bin/
 

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -35,7 +35,9 @@ COPY jvm.options /etc/cassandra/
 # Override logging: STDOUT only
 COPY logback.xml /etc/cassandra/
 
-RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
+RUN rm -f /etc/cassandra/cassandra.yaml \
+          /etc/cassandra/cassandra-rackdc.properties && \
+    chmod 0777 /etc/cassandra
 
 COPY planb-cassandra.sh /usr/local/bin/
 

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -34,7 +34,9 @@ COPY jvm.options /etc/cassandra/
 # Override logging: STDOUT only
 COPY logback.xml /etc/cassandra/
 
-RUN rm -f /etc/cassandra/cassandra.yaml && chmod 0777 /etc/cassandra
+RUN rm -f /etc/cassandra/cassandra.yaml \
+          /etc/cassandra/cassandra-rackdc.properties && \
+    chmod 0777 /etc/cassandra
 
 COPY planb-cassandra.sh /usr/local/bin/
 


### PR DESCRIPTION
The file installed from package has only comments in it and we rewrite it
fully anyway.