### PR TITLE
Don't try to automatically alter system_auth replication parameters

### DIFF
--- a/Dockerfiles/Cassandra-2/planb-cassandra.sh
+++ b/Dockerfiles/Cassandra-2/planb-cassandra.sh
@@ -105,19 +105,4 @@ if [ -n "$DC_SUFFIX" ]; then
 fi
 
 echo "Starting Cassandra ..."
-/usr/sbin/cassandra -f &
-
-#
-# Try to create admin user and drop the default superuser (we don't care if it
-# fails, that would just mean we are not the first one to do that).
-#
-sleep 60
-cqlsh -u cassandra -p cassandra \
-      -e "\
-ALTER KEYSPACE system_auth WITH replication = { 'class': 'NetworkTopologyStrategy' $(echo $REGIONS | sed "s/\([^ ]*\)-1/, '\1': $CLUSTER_SIZE/g") };\
-CREATE USER admin WITH PASSWORD '$ADMIN_PASSWORD' SUPERUSER;" \
-    && \
-    cqlsh -u admin -p "$ADMIN_PASSWORD" -e "DROP USER cassandra;"
-
-# Make sure the script don't exit at this point, if cassandra is still there.
-wait
+exec /usr/sbin/cassandra -f

--- a/Dockerfiles/Cassandra-3.0.x/planb-cassandra.sh
+++ b/Dockerfiles/Cassandra-3.0.x/planb-cassandra.sh
@@ -99,19 +99,4 @@ if [ -n "$DC_SUFFIX" ]; then
 fi
 
 echo "Starting Cassandra ..."
-/usr/sbin/cassandra -f &
-
-#
-# Try to create admin user and drop the default superuser (we don't care if it
-# fails, that would just mean we are not the first one to do that).
-#
-sleep 60
-cqlsh -u cassandra -p cassandra \
-      -e "\
-ALTER KEYSPACE system_auth WITH replication = { 'class': 'NetworkTopologyStrategy' $(echo $REGIONS | sed "s/\([^ ]*\)-1/, '\1': $CLUSTER_SIZE/g") };\
-CREATE USER admin WITH PASSWORD '$ADMIN_PASSWORD' SUPERUSER;" \
-    && \
-    cqlsh -u admin -p "$ADMIN_PASSWORD" -e "DROP USER cassandra;"
-
-# Make sure the script don't exit at this point, if cassandra is still there.
-wait
+exec /usr/sbin/cassandra -f

--- a/Dockerfiles/Cassandra-3/planb-cassandra.sh
+++ b/Dockerfiles/Cassandra-3/planb-cassandra.sh
@@ -114,19 +114,4 @@ if [ -n "$DC_SUFFIX" ]; then
 fi
 
 echo "Starting Cassandra ..."
-/usr/sbin/cassandra -R -f &
-
-#
-# Try to create admin user and drop the default superuser (we don't care if it
-# fails, that would just mean we are not the first one to do that).
-#
-sleep 60
-cqlsh -u cassandra -p cassandra \
-      -e "\
-ALTER KEYSPACE system_auth WITH replication = { 'class': 'NetworkTopologyStrategy' $(echo $REGIONS | sed "s/\([^ ]*\)-1/, '\1': $CLUSTER_SIZE/g") };\
-CREATE USER admin WITH PASSWORD '$ADMIN_PASSWORD' SUPERUSER;" \
-    && \
-    cqlsh -u admin -p "$ADMIN_PASSWORD" -e "DROP USER cassandra;"
-
-# Make sure the script don't exit at this point, if cassandra is still there.
-wait
+exec /usr/sbin/cassandra -R -f

--- a/README.rst
+++ b/README.rst
@@ -127,13 +127,23 @@ trailing dot.)
 It might be required to update the Security Group(s) of the Cassandra
 cluster to allow SSH access (TCP port 22, Jolokia Port 8778) from Odd_
 host.  After that is done, you can use `Più`_ to get SSH access and
-create your application user and the first schema:
+create the admin user, set replication factors for system_auth keyspace,
+then create your application user and the data keyspace:
 
 .. code-block:: bash
 
     $ piu 172.31.1.1 "initial Cassandra setup"  # replace private IP
     $ docker exec -it taupageapp bash
+
+    (docker)$ cqlsh -u cassandra -p cassandra \
+                -e "CREATE USER admin WITH PASSWORD '$ADMIN_PASSWORD' SUPERUSER;" \
+              && \
+              cqlsh -u admin -p $ADMIN_PASSWORD \
+                -e "DROP USER cassandra;"
+
     (docker)$ cqlsh -u admin -p $ADMIN_PASSWORD
+    cqlsh> ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-central': 3, 'eu-west': 3};
+
     cqlsh> CREATE USER myuser WITH PASSWORD '...' NOSUPERUSER;
     cqlsh> CREATE SCHEMA myschema WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west': 3, 'eu-central': 3};
 

--- a/planb/create_cluster.py
+++ b/planb/create_cluster.py
@@ -559,7 +559,7 @@ settings of system_auth keyspace as shown below.
 
 (docker)$ cqlsh -u admin -p $ADMIN_PASSWORD
 
-(cqlsh)$ ALTER KEYSPACE system_auth WITH replication = {{
+cqlsh> ALTER KEYSPACE system_auth WITH replication = {{
     'class': 'NetworkTopologyStrategy',
     {dc_list}
   }};


### PR DESCRIPTION
This proven to be dangerous in some migration scenarios, and we need to do
this exactly once.  Instead of trying to do it on every startup and hoping it
will fail if already done, just instruct the user to do it manually after
creating a cluster.