### PR TITLE
Update documentation on disabling default Cassandra superuser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,28 +124,10 @@ If you use the Hosted Zone parameter, a full name specification is
 required e.g.: ``--hosted-zone myzone.example.com.`` (note the
 trailing dot.)
 
-It might be required to update the Security Group(s) of the Cassandra
-cluster to allow SSH access (TCP port 22, Jolokia Port 8778) from Odd_
-host.  After that is done, you can use `Più`_ to get SSH access and
-create the admin user, set replication factors for system_auth keyspace,
-then create your application user and the data keyspace:
-
-.. code-block:: bash
-
-    $ piu 172.31.1.1 "initial Cassandra setup"  # replace private IP
-    $ docker exec -it taupageapp bash
-
-    (docker)$ cqlsh -u cassandra -p cassandra \
-                -e "CREATE USER admin WITH PASSWORD '$ADMIN_PASSWORD' SUPERUSER;" \
-              && \
-              cqlsh -u admin -p $ADMIN_PASSWORD \
-                -e "DROP USER cassandra;"
-
-    (docker)$ cqlsh -u admin -p $ADMIN_PASSWORD
-    cqlsh> ALTER KEYSPACE system_auth WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-central': 3, 'eu-west': 3};
-
-    cqlsh> CREATE USER myuser WITH PASSWORD '...' NOSUPERUSER;
-    cqlsh> CREATE SCHEMA myschema WITH replication = {'class': 'NetworkTopologyStrategy', 'eu-west': 3, 'eu-central': 3};
+After the create command finishes successfully, follow the on-screen
+instructions to create the admin superuser, set replication factors for
+system_auth keyspace and then create your application user and the data
+keyspace.
 
 The generated administrator password is available inside the docker
 container in an environment variable ``ADMIN_PASSWORD``.


### PR DESCRIPTION
Dropping user 'cassandra' doesn't seem to be a reliable advice: we've seen the
user reappearing under some circumstances.  The official documentation says,
though: remove the superuser flag from it and set the password to something
not easily guessable.  Add links to the doc from DataStax (version 2 and 3).

Don't duplicate auth setup instructions in the README: follow the on-screen
instruction printed by the create command instead.