### PR TITLE
Enable logging of GC details to standard output

### DIFF
--- a/Dockerfiles/Cassandra-2/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-2/cassandra-env.sh
@@ -233,13 +233,15 @@ if [ "$JVM_ARCH" = "64-Bit" ] ; then
 fi
 
 # GC logging options -- uncomment to enable
-# JVM_OPTS="$JVM_OPTS -XX:+PrintGCDetails"
-# JVM_OPTS="$JVM_OPTS -XX:+PrintGCDateStamps"
-# JVM_OPTS="$JVM_OPTS -XX:+PrintHeapAtGC"
-# JVM_OPTS="$JVM_OPTS -XX:+PrintTenuringDistribution"
-# JVM_OPTS="$JVM_OPTS -XX:+PrintGCApplicationStoppedTime"
-# JVM_OPTS="$JVM_OPTS -XX:+PrintPromotionFailure"
+JVM_OPTS="$JVM_OPTS -XX:+PrintGCDetails"
+JVM_OPTS="$JVM_OPTS -XX:+PrintGCDateStamps"
+JVM_OPTS="$JVM_OPTS -XX:+PrintHeapAtGC"
+JVM_OPTS="$JVM_OPTS -XX:+PrintTenuringDistribution"
+JVM_OPTS="$JVM_OPTS -XX:+PrintGCApplicationStoppedTime"
+JVM_OPTS="$JVM_OPTS -XX:+PrintPromotionFailure"
 # JVM_OPTS="$JVM_OPTS -XX:PrintFLSStatistics=1"
+
+# Don't specify the file, we want the GC logs on stdout.
 # JVM_OPTS="$JVM_OPTS -Xloggc:/var/log/cassandra/gc-`date +%s`.log"
 # If you are using JDK 6u34 7u2 or later you can enable GC log rotation
 # don't stick the date in the log name if rotation is on.

--- a/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
@@ -124,7 +124,8 @@ esac
 JVM_OPTS="$JVM_OPTS -javaagent:/opt/jolokia/jolokia-jvm-agent.jar=port=8778,host=$LISTEN_ADDRESS"
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+# Don't specify the file, we want the GC logs on stdout.
+#JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.

--- a/Dockerfiles/Cassandra-3.0.x/jvm.options
+++ b/Dockerfiles/Cassandra-3.0.x/jvm.options
@@ -103,6 +103,6 @@
 -XX:+PrintPromotionFailure
 #-XX:PrintFLSStatistics=1
 #-Xloggc:/var/log/cassandra/gc.log
--XX:+UseGCLogFileRotation
--XX:NumberOfGCLogFiles=10
--XX:GCLogFileSize=10M
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=10
+#-XX:GCLogFileSize=10M

--- a/Dockerfiles/Cassandra-3/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3/cassandra-env.sh
@@ -124,7 +124,8 @@ esac
 JVM_OPTS="$JVM_OPTS -javaagent:/opt/jolokia/jolokia-jvm-agent.jar=port=8778,host=$LISTEN_ADDRESS"
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+# Don't specify the file, we want the GC logs on stdout.
+#JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.

--- a/Dockerfiles/Cassandra-3/jvm.options
+++ b/Dockerfiles/Cassandra-3/jvm.options
@@ -235,9 +235,9 @@
 -XX:+PrintPromotionFailure
 #-XX:PrintFLSStatistics=1
 #-Xloggc:/var/log/cassandra/gc.log
--XX:+UseGCLogFileRotation
--XX:NumberOfGCLogFiles=10
--XX:GCLogFileSize=10M
+#-XX:+UseGCLogFileRotation
+#-XX:NumberOfGCLogFiles=10
+#-XX:GCLogFileSize=10M
 
 -XX:+AggressiveOpts
 -XX:+UseCompressedOops


### PR DESCRIPTION
Versions 3.0 and 3.x were suffering from default configuration that tries to
write the GC logs to a non-existant directory.

Fix #111