### PR TITLE
Add refreshing client to prevent failures in a middle of longish ops

### DIFF
--- a/planb/cli.py
+++ b/planb/cli.py
@@ -2,7 +2,7 @@ import re
 import click
 import logging
 
-from .common import ec2_client, list_instances
+from .common import boto_client, list_instances
 from .show_cluster import show_instances
 from .create_cluster import create_cluster
 from .update_cluster import update_cluster
@@ -115,6 +115,6 @@ def update(cluster_name: str,
 def nodes(region: str, cluster_name: str):
     # TODO: we should extend it to list of regions
     # TODO: we could derive the regions a cluster is deployed to from SRV DNS record
-    ec2 = ec2_client(region)
+    ec2 = boto_client('ec2', region)
     instances = list_instances(ec2, cluster_name)
     show_instances(instances)

--- a/planb/common.py
+++ b/planb/common.py
@@ -10,14 +10,15 @@ from datetime import datetime
 
 class SessionRefreshingBotoClient(object):
 
-    def __init__(self, service_name: str, region_name: str):
+    def __init__(self, profile_name: str, service_name: str, region_name: str):
+        self._profile_name = profile_name
         self._service_name = service_name
         self._region_name = region_name
         self._refresh_session()
 
     def _refresh_session(self):
         # creating the session explicitly avoids use of stale credentials
-        session = boto3.session.Session()
+        session = boto3.session.Session(profile_name=self._profile_name)
         self._client = session.client(self._service_name, self._region_name)
 
     def _wrap_callable(self, name: str):
@@ -41,8 +42,9 @@ class SessionRefreshingBotoClient(object):
         return self._wrap_callable(name) if callable(attr) else attr
 
 
-def boto_client(service_name: str, region_name: str = None) -> object:
-    return SessionRefreshingBotoClient(service_name, region_name)
+def boto_client(service_name: str, region_name: str = None,
+                profile_name: str = None) -> object:
+    return SessionRefreshingBotoClient(profile_name, service_name, region_name)
 
 
 def json_serial(obj):
@@ -120,7 +122,7 @@ def setup_sns_topics_for_alarm(regions: list, topic_name: str, email: str) -> li
 
     result = {}
     for region in regions:
-        sns = boto3.client('sns', region_name=region)
+        sns = boto_client('sns', region)
         resp = sns.create_topic(Name=topic_name)
         topic_arn = resp['TopicArn']
         if email:
@@ -131,9 +133,7 @@ def setup_sns_topics_for_alarm(regions: list, topic_name: str, email: str) -> li
 
 def create_auto_recovery_alarm(region: str, cluster_name: str,
                                instance_id: str, alarm_sns_topic_arn: str):
-    session = boto3.Session(profile_name='planb_autorecovery')
-    cw = session.client('cloudwatch', region_name=region)
-
+    cw = boto_client('cloudwatch', region, profile_name='planb_autorecovery')
     alarm_name = '{}-{}-auto-recover'.format(cluster_name, instance_id)
 
     alarm_actions = ['arn:aws:automate:{}:ec2:recover'.format(region)]
@@ -162,7 +162,7 @@ def make_instance_profile_name(cluster_name: str) -> str:
 
 
 def get_instance_profile(cluster_name: str) -> dict:
-    iam = boto3.client('iam')
+    iam = boto_client('iam')
     try:
         profile_name = make_instance_profile_name(cluster_name)
         profile = iam.get_instance_profile(InstanceProfileName=profile_name)
@@ -178,7 +178,7 @@ def create_instance_profile(cluster_name: str):
     role_name = 'role-{}'.format(cluster_name)
     policy_name = 'policy-{}-datavolume'.format(cluster_name)
 
-    iam = boto3.client('iam')
+    iam = boto_client('iam')
 
     profile = iam.create_instance_profile(InstanceProfileName=profile_name)
 

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -13,7 +13,7 @@ import io
 import os
 
 # TODO: can we avoid the explicit list here?
-from .common import ec2_client, \
+from .common import boto_client, \
     dump_dict_as_file, load_dict_from_file, \
     dump_user_data_for_taupage, list_instances, \
     override_ephemeral_block_devices, \
@@ -507,7 +507,7 @@ def list_instances_to_update(ec2: object, cluster_name: str) -> list:
 
 
 def update_cluster(options: dict):
-    ec2 = ec2_client(options['region'])
+    ec2 = boto_client('ec2', options['region'])
     instances = list_instances_to_update(ec2, options['cluster_name'])
     if not instances:
         return


### PR DESCRIPTION
A class SessionRefreshingBotoClient wraps any callable method of the actual
client object and tries to reopen session if RequestExpired error is raised.

The user needs to ensure that credentials are refreshed timely, e.g. by
running `zaws login -r` in the background.