### PR TITLE
Dump tokens after Cassandra started

### DIFF
--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -8,11 +8,12 @@ EXPOSE 7001 7199 8778 9042
 ENV CASSIE_VERSION=3.11.2
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN apt-get update && apt-get -y install gnupg
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
 
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install vim less sysstat \
+RUN apt-get -y install vim less sysstat netcat \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \
     apt-get clean && \
@@ -38,6 +39,7 @@ RUN rm -f /etc/cassandra/cassandra.yaml \
           /etc/cassandra/cassandra-rackdc.properties && \
     chmod 0777 /etc/cassandra
 
+COPY dump-ring-token.sh  /usr/local/bin/
 COPY planb-cassandra.sh /usr/local/bin/
 
 ENV HOME=/var/lib/cassandra

--- a/Dockerfiles/Cassandra-3/dump-ring-token.sh
+++ b/Dockerfiles/Cassandra-3/dump-ring-token.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+function waiting_client_port_open() {
+    local port=$1
+
+    while ! nc -z localhost $port; do   
+        sleep 10
+    done
+}
+
+waiting_client_port_open 9042
+
+IP=$(curl 'http://169.254.169.254/latest/meta-data/local-ipv4')
+TOKENS=$(nodetool ring | grep ${IP} | awk '{print $NF ","}' | xargs)
+echo ${TOKENS:0:-1}

--- a/Dockerfiles/Cassandra-3/planb-cassandra.sh
+++ b/Dockerfiles/Cassandra-3/planb-cassandra.sh
@@ -119,5 +119,9 @@ if [ -n "$DC_SUFFIX" ]; then
     echo "dc_suffix=$DC_SUFFIX" > /etc/cassandra/cassandra-rackdc.properties
 fi
 
+# Initialze the script to dump all the token belong to this node in the ring.
+mkdir -p ${CASSANDRA_DATA_DIR}/metadata
+nohup /usr/local/bin/dump-ring-token.sh > ${CASSANDRA_DATA_DIR}/metadata/ring-tokens &
+
 echo "Starting Cassandra ..."
 exec /usr/sbin/cassandra -R -f


### PR DESCRIPTION
Hi
In order to make IT compliance we need to perform backup/restore for our Cassandra cluster. 
In this document: [Restoring a snapshot into a new cluster](https://docs.datastax.com/en/dse/6.0/dse-admin/datastax_enterprise/operations/opsSnapshotRestoreNewCluster.html), it mentioned that we need to dump tokens in order to recover from a snapshot.

The idea is that we can dump the token after Cassandra started in data folder (Saying that `/var/lib/cassandra/metadata`) and we take the EBS snapshots. So that in the new cluster, we can attach the EBS volume (which created from the snapshot) and find this file in data folder.

Another way is that we can manually dump the tokens whenever new cluster / nodes are added, but we think this way is more error-prone since people may forget to do it. 

Author: charlie.chang@zalando.de


