### PR TITLE
Fix default config for version 4

### DIFF
--- a/Dockerfiles/Cassandra-4/cassandra_template.yaml
+++ b/Dockerfiles/Cassandra-4/cassandra_template.yaml
@@ -1042,7 +1042,7 @@ dynamic_snitch_badness_threshold: 0.1
 #
 server_encryption_options:
     # set to true for allowing secure incoming connections
-    enabled: false
+    enabled: true
     # If enabled and optional are both set to true, encrypted and unencrypted connections are handled on the storage_port
     optional: false
     # if enabled, will open up an encrypted listening socket on ssl_storage_port. Should be used


### PR DESCRIPTION
Ran into this error while testing:
`
ERROR Exception encountered during startup: Encryption must be enabled in server_encryption_options when using peer-to-peer security. server_encryption_options.internode_encryption = all
`

Setting enabled to true fixes the issue and the server starts up normally.