### PR TITLE
Release new versions + use new base image

### DIFF
--- a/Dockerfiles/Cassandra-2.2/Dockerfile
+++ b/Dockerfiles/Cassandra-2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 ARG CASSANDRA_VERSION
 
 MAINTAINER Zalando SE
@@ -11,8 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install apt-utils gnupg
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 22x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
-RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb https://downloads.apache.org/cassandra/debian 22x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -y install vim less sysstat \

--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 ARG CASSANDRA_VERSION
 
 MAINTAINER Zalando SE
@@ -11,8 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install apt-utils gnupg
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 21x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
-RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb https://downloads.apache.org/cassandra/debian 21x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -y install vim less sysstat \

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 ARG CASSANDRA_VERSION
 
 MAINTAINER Zalando SE
@@ -11,8 +11,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install apt-utils gnupg
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 30x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
-RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb https://downloads.apache.org/cassandra/debian 30x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -y install vim less sysstat \

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 ARG CASSANDRA_VERSION
 
 MAINTAINER Zalando SE
@@ -11,13 +11,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install apt-utils gnupg
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
-RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb https://downloads.apache.org/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -y install vim less sysstat \
     cassandra=$CASSANDRA_VERSION \
     cassandra-tools=$CASSANDRA_VERSION && \
+    apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfiles/Cassandra-4/Dockerfile
+++ b/Dockerfiles/Cassandra-4/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:latest
+FROM registry.opensource.zalan.do/library/openjdk-8:latest
 ARG CASSANDRA_VERSION
 
 MAINTAINER Zalando SE
@@ -11,13 +11,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install apt-utils gnupg
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 40x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
-RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN echo "deb https://downloads.apache.org/cassandra/debian 40x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
+RUN curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
 RUN apt-get -y update
 
 RUN apt-get -y install vim less sysstat \
     cassandra=$CASSANDRA_VERSION \
     cassandra-tools=$CASSANDRA_VERSION && \
+    apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/build.sh
+++ b/build.sh
@@ -27,8 +27,8 @@ function build_docker() {
 }
 
 # to contain the side-effect of cd inside the function, make it look like Lisp:
-(build_docker	4	4.0~alpha1	4)
-(build_docker	3	3.11.4		3)
-(build_docker	3.0.x	3.0.18		3.0)
-(build_docker	2.2	2.2.14		2.2)
-(build_docker	2	2.1.21		2)
+(build_docker	4	4.0~beta2	4)
+(build_docker	3	3.11.8		3)
+(build_docker	3.0.x	3.0.22		3.0)
+(build_docker	2.2	2.2.18		2.2)
+(build_docker	2	2.1.22		2)


### PR DESCRIPTION
Use openjdk-8 base image and bump versions to the latest releases.